### PR TITLE
Chore documentation

### DIFF
--- a/etl/README.md
+++ b/etl/README.md
@@ -58,6 +58,8 @@ OU_LEVEL='6' #hierarchical level of orgUnits, numeric
 
 GEE_PROJECT='your-project-name'
 GEE_SERVICE_ACCOUNT='your-account@your-project.iam.gserviceaccount.com'
+#optional, empty will import all variables
+GEE_VARIABLES="pridec_climate_var1,pridec_climate_var2"
 
 #only needed for import_pivot data services
 PIVOT_URL="pivot-prod-url"
@@ -66,23 +68,29 @@ PIVOT_TOKEN="d2pat_your-pivot-token"
 
 Individual environmental variables can also be provided to the docker service via the `--env` flag when running.
 
-## Available commands
+## Available tasks
 
-The available commands can be queried by running:
+The docker image contains several PRIDE-C ETL tasks. The available tasks can be queried by running:
 
 ```
 docker compose run etl --help
 ```
 
-It is recommended to run commands with the `--rm` flag to prevent orphaned containers.
+It is recommended to run tasks with the `--rm` flag to prevent orphaned containers.
 
 # General PRIDE-C workflow
 
 ## 1. Import health and climate data into PRIDE-C instance
 
-### 1.1 `import_gee` service to import GEE climate varables into DHIS2 instance [once per month]
+### 1.1 `import_gee` task to import GEE climate varables into DHIS2 instance [once per month]
 
-This requires having a `.gee-private-key.json` in the root directory as well as a `GEE_SERVICE_ACCOUNT` in `.env`. There is one climate variable that is specific to Ifanadiana (`pridec_climate_floodedRice`), but could be applied to other regions if they provide a polygon of ricefields.
+This requires having a `.gee-private-key.json` in the root directory as well as a `GEE_SERVICE_ACCOUNT` in `.env`. There is one climate variable that is specific to Ifanadiana (`pridec_climate_floodedRice`), but could be applied to other regions if they provide a polygon of ricefields. By default, it imports all ten PRIDE-C climate variables. To import a sub-selection, provide the list of variable names via the `GEE_VARIABLES` environmental variable. Available variables can be listed by querying the task help flag:
+
+```
+docker compose run --rm etl import_gee --help
+```
+
+To launch the task with defaults following the `.env` file in your directory, run:
 
 ```
 docker compose run --rm etl import_gee
@@ -94,9 +102,9 @@ In order for this data to be available via `analytics` calls, the Analytics Tabl
 docker compose run --rm etl build_analytics
 ```
 
-### 1.2  `import_pivot` service to import Madagascar specific data (Pivot-only) [once per month]
+### 1.2  `import_pivot` task to import Madagascar specific data (Pivot-only) [once per month]
 
-This is an optional service to only be run on the Pivot PRIDE-C instance used by Pivot. It creates the `pridec_historical_` variables that are needed for predictions. This is needed because there is some cleaning and formatting we do with the raw `dataElements` to have high quality variables to predict.
+This is an optional task to only be run on the Pivot PRIDE-C instance used by Pivot. It creates the `pridec_historical_` variables that are needed for predictions. This is needed because there is some cleaning and formatting we do with the raw `dataElements` to have high quality variables to predict.
 
 ```
 docker compose run --rm etl import_pivot_com
@@ -113,7 +121,7 @@ The forecast step should be run for each dataElement being predicted. Its steps 
 2. Using the data in the `forecast` workflow (this is available in a seperate docker image [here](https://hub.docker.com/r/mvevans89/pridec_forecast))
 3. `POST`ing the forecasts to the PRIDE-C instance
 
-### 2.1. `fetch` service to download climate, disease, and geospatial data
+### 2.1. `fetch` task to download climate, disease, and geospatial data
 
 This uses the ENV_VARIABLES stored in the `.env` file. It needs to be updated when using a different DHIS2 instance or dataSource following `.env.example`. This step is run for every `dataElement` that you wish to predict.
 

--- a/etl/cli.sh
+++ b/etl/cli.sh
@@ -6,11 +6,11 @@ shift || true
 
 # Function to print usage/help
 print_usage() {
-    echo "Usage: docker compose run etl <command> [args]"
+    echo "Usage: docker compose run etl <task> [args]"
     echo ""
-    echo "Available commands:"
+    echo "Available tasks:"
     echo "  --help, -h           - View usage documentation."
-    echo "  import_gee           - Import climate data from GEE to PRIDE-C instance."
+    echo "  import_gee           - Import climate data from GEE to PRIDE-C instance. Can supply variables to import as env var GEE_VARIABLES."
     echo "  import_pivot_com     - Import historical COM data from Pivot instance to PRIDE-C instance. Pivot use only."
     echo "  import_pivot_csb     - Import historical CSB data from Pivot instance to PRIDE-C instance. Pivot use only."
     echo "  fetch_climate        - Download climate data from PRIDE-C instance to input folder."
@@ -25,6 +25,7 @@ print_usage() {
     echo "Examples:"
     echo "  docker compose run etl fetch_geojson"
     echo "  docker compose run --env-from-file .env --env DRYRUN='true' etl fetch_climate"
+    echo "  docker compose run --env GEE_VARIABLES='pridec_climate_temperatureMean,pridec_climate_windspeed' --env LOG_LEVEL='INFO' etl import_gee"
     echo ""
     echo "Notes:"
     echo "- Automatically uses .env file in current directory." 

--- a/etl/scripts/build_analytics.py
+++ b/etl/scripts/build_analytics.py
@@ -1,3 +1,26 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: build_analytics
+
+Usage:
+-   Builds analytics table on DHIS2 PRIDE-C instance. 
+
+Notes:
+-   Depending on the size of your instance, this can take some time. 
+    Check the url for the `completed` status before running other steps.
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL,  setup_logging
 from requests.auth import HTTPBasicAuth
 import logging

--- a/etl/scripts/calc_CSB_alerts.py
+++ b/etl/scripts/calc_CSB_alerts.py
@@ -1,3 +1,24 @@
+def print_help():
+    print(f"""
+Task: calc_CSB_alerts
+
+Usage:
+-   Estimates the number of health facilities expecting more usage than average of prior three years and
+          posts this information to the PRIDE-C instance
+
+Notes:
+-   This currently runs only on the Pivot PRIDE-C instance due to specific configurations.
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, dryRun, setup_logging, check_envvars
 from pivot_dhis_tools import post_dataElements, pridec_calc_CSB_alerts
 import os

--- a/etl/scripts/fetch_pridec_climate.py
+++ b/etl/scripts/fetch_pridec_climate.py
@@ -1,3 +1,26 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: fetch_pridec_climate
+
+Usage:
+-   Downloads PRIDE-C climate data from DHIS2 instance and saves into `input` folder. 
+
+Notes:
+-   Climate data will be downloaded for the orgUnit level specified in .env via OU_LEVEL.
+    Fokontany = 6. CSB = 5.
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, PARENT_OU, OU_LEVEL, setup_logging, check_envvars
 from pivot_dhis_tools import pridec_fetch_climate
 import os

--- a/etl/scripts/fetch_pridec_disease.py
+++ b/etl/scripts/fetch_pridec_disease.py
@@ -1,3 +1,28 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: fetch_pridec_disease
+
+Usage:
+-   Downloads PRIDE-C disease data from DHIS2 instance and saves into `input` folder. 
+
+Notes:
+-   Disease data will be downloaded for the orgUnit level specified in .env via OU_LEVEL.
+    Fokontany = 6. CSB = 5.
+-   The dataElement with code corresponding to env var DISEASE_CODE will be downloaded.
+    Options: 
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, PARENT_OU, OU_LEVEL, DISEASE_CODE, setup_logging, check_envvars
 from pivot_dhis_tools import pridec_fetch_disease
 import os
@@ -17,6 +42,8 @@ check_envvars(required_vars = {
             'DISEASE_CODE': DISEASE_CODE
         }
 )
+
+#TO DO: Update to get OU automatically based on disease code
 
 logger.info("Fetching disease data %s from %s", DISEASE_CODE, DHIS_URL)
 

--- a/etl/scripts/fetch_pridec_geojson.py
+++ b/etl/scripts/fetch_pridec_geojson.py
@@ -1,3 +1,26 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: fetch_pridec_geojson
+
+Usage:
+-   Downloads geojson data of orgUnit polygons from DHIS2 instance and saves into `input` folder. 
+
+Notes:
+-   Geojson will be downloaded for the orgUnit level specified in .env via OU_LEVEL.
+    Fokontany = 6. CSB = 5.
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, OU_LEVEL, PARENT_OU, setup_logging, check_envvars
 from requests.auth import HTTPBasicAuth
 import logging

--- a/etl/scripts/import_gee.py
+++ b/etl/scripts/import_gee.py
@@ -1,3 +1,31 @@
+import argparse
+from pridec_gee import AVAILABLE_VARIABLES
+
+def print_help():
+    print(f"""
+Task: import_gee
+
+Usage:
+-   Imports climate variables from GEE into DHIS2 instance
+
+Notes:
+-   The selection of climate variables is provided via an environmental variable
+    `GEE_VARIABLES`, which is a string with variable names separated by commas.
+    Example: `GEE_VARIABLES='pridec_climate_temperatureMean,pridec_climate_mndwi'`
+
+The available variables are:
+{chr(10).join(f'  - {v}' for v in AVAILABLE_VARIABLES)}
+""")
+    
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, PARENT_OU, GEE_SERVICE_ACCOUNT, GEE_VARIABLES, dryRun, setup_logging, check_envvars
 import json
 import ee

--- a/etl/scripts/import_pivot_COM.py
+++ b/etl/scripts/import_pivot_COM.py
@@ -1,3 +1,27 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: import_pivot_COM
+
+Usage:
+-   Import disease cases reported at community health sites during prior three months from Pivot DHIS2 instance to PRIDE-C instance
+
+Notes:
+-   This requires `PIVOT_URL` and `PIVOT_TOKEN` in .env
+-   The fokontany imported are limited to those that were supported from YEAR.
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
+
 from config import DHIS_TOKEN, DHIS_URL, PIVOT_URL, PIVOT_TOKEN, dryRun, setup_logging, check_envvars
 from requests.auth import HTTPBasicAuth
 import pandas as pd

--- a/etl/scripts/import_pivot_CSB.py
+++ b/etl/scripts/import_pivot_CSB.py
@@ -1,3 +1,25 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: import_pivot_CSB
+
+Usage:
+-   Import disease cases reported at CSBs during prior three months from Pivot DHIS2 instance to PRIDE-C instance
+
+Notes:
+-   This requires `PIVOT_URL` and `PIVOT_TOKEN` in .env
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, PIVOT_URL, PIVOT_TOKEN, dryRun, setup_logging, check_envvars
 from requests.auth import HTTPBasicAuth
 import pandas as pd

--- a/etl/scripts/post_forecast.py
+++ b/etl/scripts/post_forecast.py
@@ -1,3 +1,23 @@
+def print_help():
+    print(f"""
+Task: post_forecast
+
+Usage:
+-   POSTs a forecast in the form of output/forecast.json to the PRIDE-C instance
+
+Notes:
+-   None
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, dryRun, setup_logging, check_envvars
 from pivot_dhis_tools import post_dataElements
 import os

--- a/etl/scripts/update_pridec_key.py
+++ b/etl/scripts/update_pridec_key.py
@@ -1,3 +1,23 @@
+def print_help():
+    print(f"""
+Task: update_pridec_key
+
+Usage:
+-   Updates a PRIDE-C key in teh datastore that is used to signal a local cache to re-download data.
+          
+Notes:
+-   Should be run after a monthly update
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
 from config import DHIS_TOKEN, DHIS_URL, dryRun, setup_logging, check_envvars
 from pivot_dhis_tools import pridec_update_key
 import os

--- a/forecast/entrypoint.R
+++ b/forecast/entrypoint.R
@@ -114,12 +114,12 @@ if(forecast_status){
 
     if(report_status){
 
-      cli::cli_alert_success(paste0("SUCCESS: HTML report created at ", output_dir, "forecast_report.html"))
+      cli::cli_alert_success(paste0("SUCCESS: HTML report created at ", output_dir, "/forecast_report.html"))
       
     } else {
 
       cli::cli_alert_warning(paste0("WARNING: Forecast created but report failed. Created simple report.",
-                              "Investigate", output_dir, "forecast.json and ", output_dir, "input_data.RData.",
+                              "Investigate", output_dir, "/forecast.json and ", output_dir, "/input_data.RData.",
                               "Report can be re-run using `Rscript -e 'PRIDEC::create_forecast_report()'."))
     }
 

--- a/labnotebook-docker_workflow.md
+++ b/labnotebook-docker_workflow.md
@@ -17,6 +17,36 @@ Building and pushing to Docker Hub (both images at once)
 docker compose -f compose-build.yaml build --no-cache && docker compose push
 ```
 
+## 2026-05-04
+
+Running PRIDE-C update and continuing to have issue with INLA"
+
+```
+Error: INLA model failed with error message:
+ $ operator is invalid for atomic vectors
+In addition: Warning message:
+In parallel::mclapply(1:cs$nconfig, (function(k) { :
+  scheduled cores 2, 4, 7, 10, 9 encountered errors in user code, all values of the jobs will be affected
+Execution halted
+```
+
+Before, I thought this was due to how INLA configs were being passed by that has been fixed in the PRIDE-C package with this commit: https://github.com/Pivot-Madagascar/PRIDEC-package/commit/d97120c7ec8474b85f385d43e34331ad74c36710#diff-286214608d5669437d8e884f9aadccba8f00e9910b751d433519f37057c66cf0
+
+I am trying to solve this in the R Package but I think in the end it may be a version issue or a matrix library issue. Unfortunately this is now done via the geolight package, so I need to update it in that first.
+
+
+**TO DO:**
+- update how the options/arguments are provided to use `--` for parsing so that I can still debug things and run them interactively
+
+## 2026-04-27
+
+Updated the code to use the new pridec_gee package. I fully forgot to make an issue for this, but one kind of already existed. This included updating teh code to use a subset of variables and setting the python package versions
+
+Adding soem informative help messages to the etl python scripts so tehy can be run with the -h or --help flag and provide useful information.
+
+**TO DO:**
+
+
 ## 2026-04-24
 
 I have updated the pridec_gee package to take variable names now. This is a breaking change and so it needs to be updated here.


### PR DESCRIPTION
Addresses issues of documentation, specially user-facing documentation via help flags -h and --help.

Updates language to refer to specific calls to an image/docker as a "task", while `etl` and `forecast` remain "services"

Closes issue #2 