### PR TITLE
use explict versioning for images fixes #9

### DIFF
--- a/compose-build.yaml
+++ b/compose-build.yaml
@@ -8,7 +8,7 @@ services:
     build:
       context: ./etl
       dockerfile: Dockerfile
-    image: mvevans89/pridec_etl:latest
+    image: mvevans89/pridec_etl:0.1.0
     # network_mode: "host"
     # volumes:
     #  - type: bind
@@ -34,7 +34,7 @@ services:
     build: 
       context: ./forecast
       dockerfile: Dockerfile
-    image: mvevans89/pridec_forecast:latest
+    image: mvevans89/pridec_forecast:0.1.0
     # network_mode: "host"
     # cap_add:
     #   - SYS_NICE  

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ name: pridec
 services:
 
   etl:
-    image: mvevans89/pridec_etl:latest
+    image: mvevans89/pridec_etl:0.1.0
     network_mode: "host"
     env_file:
     - path: ${HOST_PWD:-.}/.env
@@ -35,7 +35,7 @@ services:
        read_only: true
 
   forecast:
-    image: mvevans89/pridec_forecast:latest
+    image: mvevans89/pridec_forecast:0.1.0
     network_mode: "host"
     env_file:
     - path: ${HOST_PWD:-.}/.env

--- a/forecast/Dockerfile
+++ b/forecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM mvevans89/geolight:latest
+FROM mvevans89/geolight:0.1.0
 
 WORKDIR /app
 

--- a/labnotebook-docker_workflow.md
+++ b/labnotebook-docker_workflow.md
@@ -14,8 +14,12 @@ DHIS2_TOKEN="d2pat_odhYW86O8auDuQ73u4r3HElEJxMFQziM3326734980"
 Building and pushing to Docker Hub (both images at once)
 
 ```
-docker compose -f compose-build.yaml build --no-cache && docker compose push
+docker compose -f compose-build.yaml build --no-cache && docker compose -f compose-build.yaml push
 ```
+
+## 2026-06-25
+
+Updated the images to using explicit versioning, beginning with 0.1.0, to help with conflicts from local vs. built images. This is realted to issue #9.
 
 ## 2026-05-25
 


### PR DESCRIPTION
This institutes a versioning system for the docker images. In development it will be 0.1.x, until the first release which will be 1.0.0.  This should ensure that correct image versions are used locally and by everyone on the team. Image versions will need to be updated with every update to code, in both compose files.