### PR TITLE
allow for local CSB alert calculations

### DIFF
--- a/etl/cli.sh
+++ b/etl/cli.sh
@@ -84,6 +84,10 @@ calc_CSB_alerts)
     python scripts/calc_CSB_alerts.py "$@"
     ;;
 
+calc_orgUnit_alerts)
+    python scripts/calc_orgUnit_alerts.py "$@"
+    ;;
+
 update_key)
     python scripts/update_pridec_key.py "$@"
     ;;

--- a/etl/cli.sh
+++ b/etl/cli.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-COMMAND="$1"
+TASK="$1"
 shift || true  
 
 # Function to print usage/help
@@ -19,9 +19,10 @@ print_usage() {
     echo "  validate_inputs      - Validate input files for forecasting in input/ folder. "
     echo "                         Saves validated inputs as input/config_valid.json, input/input_valid.json, and input/polygon_valid.geojson."
     echo "                         See 'docker compose run etl validate_inputs --help' for available arguments."
+    echo "  calc_CSB_alerts      - Calculate the number of CSB on alert for this month and post to PRIDE-C instance."
+    echo "  calc_orgUnit_alerts  - Calculate the number of orgUnits on alert and save as output/alerts.json. More generalizable version of calc_CSB_alerts."
     echo "  post_forecast        - Post forecast to PRIDE-C instance."
     echo "  build_analytics      - Build the analytics table on PRIDE-C instance. This can take 10-15 minutes."
-    echo "  calc_CSB_alerts      - Calculate the number of CSB on alert for this month and post to PRIDE-C instance."
     echo "  update_key           - Update the datastore key used to trigger PRIDE-C cache reset every month." 
     echo "                         Run at the end of all updates."
     echo ""
@@ -37,12 +38,12 @@ print_usage() {
 }
 
 # Show help if no command or -h/--help
-if [ -z "$COMMAND" ] || [ "$COMMAND" = "-h" ] || [ "$COMMAND" = "--help" ]; then
+if [ -z "$TASK" ] || [ "$TASK" = "-h" ] || [ "$TASK" = "--help" ]; then
     print_usage
     exit 0
 fi
 
-case "$COMMAND" in
+case "$TASK" in
 import_gee)
     python scripts/import_gee.py "$@"
     ;;
@@ -88,7 +89,7 @@ update_key)
     ;;
 
 *)
-    echo "Unknown command: $COMMAND"
+    echo "Unknown etl task: $TASK"
     echo ""
     print_usage
     exit 1

--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -10,7 +10,7 @@ geopandas>=1.1.3
 ee
 earthengine-api
 pridec_gee @ git+https://github.com/Pivot-Madagascar/pridec_gee@v0.2.1
-pivot_dhis_tools @ git+https://github.com/Pivot-Madagascar/pivot_dhis_tools@v0.1.1
+pivot_dhis_tools @ git+https://github.com/Pivot-Madagascar/pivot_dhis_tools@v0.1.2
 
 
 

--- a/etl/scripts/calc_orgUnit_alerts.py
+++ b/etl/scripts/calc_orgUnit_alerts.py
@@ -1,0 +1,60 @@
+import argparse
+
+def print_help():
+    print(f"""
+Task: calc_orgUnit_alerts
+
+Usage:
+-   Estimates the number of orgUnits expecting more usage than average of prior three years and
+          saves to output/alerts.json
+""")
+
+parser = argparse.ArgumentParser(add_help=False)  # disable default help
+parser.add_argument("--help", "-h", action="store_true")
+
+args = parser.parse_args()
+
+if args.help:
+    print_help()
+    exit(0)
+
+from config import DHIS_TOKEN, DHIS_URL, dryRun, setup_logging, check_envvars, PARENT_OU, OU_LEVEL, DISEASE_CODE, ALERT_NAME
+from pivot_dhis_tools import post_dataElements, pridec_calc_orgUnit_alerts
+import os
+import json
+
+import logging
+
+setup_logging()
+
+logger = logging.getLogger("calc_orgUnit_alerts")
+
+logger.info("Estimating orgUnits on alert at level %s below parent %s for %s", OU_LEVEL, PARENT_OU, DISEASE_CODE)
+
+check_envvars(required_vars = {
+            'PARENT_OU': PARENT_OU,
+            'OU_LEVEL': OU_LEVEL,
+            'DISEASE_CODE': DISEASE_CODE})
+
+#load local data by default
+with open("input/disease_data.json") as f:
+    historic_json = json.load(f)
+
+with open("output/forecast.json") as f:
+    forecast_json = json.load(f)
+
+disease_code_short = DISEASE_CODE.replace("pridec_historic_", "")
+
+#automatically does for current month
+json_alert = pridec_calc_orgUnit_alerts(dhis_url = DHIS_URL, 
+                                        parent_ou = PARENT_OU,
+                                        ou_level = OU_LEVEL,
+                                        disease_code = disease_code_short,
+                                        forecast_json = forecast_json,
+                                        historic_json = historic_json,
+                                        alert_name = ALERT_NAME,
+                                        token = DHIS_TOKEN)
+
+
+with open("output/alerts.json", "w") as f:
+    json.dump(json_alert, f, indent=2)

--- a/etl/scripts/config.py
+++ b/etl/scripts/config.py
@@ -24,6 +24,7 @@ PIVOT_TOKEN = os.environ.get('PIVOT_TOKEN')
 PARENT_OU = os.environ.get('PARENT_OU')
 OU_LEVEL = os.environ.get('OU_LEVEL')
 DISEASE_CODE = os.environ.get('DISEASE_CODE')
+ALERT_NAME = os.environ.get('ALERT_NAME')
 
 #gee info
 GEE_PROJECT = os.environ.get('GEE_PROJECT')

--- a/etl/scripts/post_forecast.py
+++ b/etl/scripts/post_forecast.py
@@ -6,6 +6,7 @@ Task: post_forecast
 
 Usage:
 -   POSTs a forecast in the form of output/forecast.json to the PRIDE-C instance
+-   POSTs calculated PRIDE-C Alerts from output/alerts.json to the PRIDE-C instance
 
 Notes:
 -   None
@@ -38,13 +39,29 @@ check_envvars(required_vars = {
 
 logger.info("Posting forecasts to %s", DHIS_URL)
 
+forecast_payload = None
+alert_payload = None
+
 try:
     with open('output/forecast.json', 'r') as file:
-        json_payload = json.load(file)
-except FileNotFoundError as e:
-        logger.error("The file 'output/forecast.json' was not found. Run the forecast step first.")
-        raise SystemExit(1) from e
+        forecast_payload = json.load(file)
+except FileNotFoundError:
+        logger.warning("The file 'output/forecast.json' was not found and will not be posted. Run the forecast step first.")
 
-post_dataElements(dhis_url = DHIS_URL, payload = json_payload,
-                   token= DHIS_TOKEN, dryRun=dryRun)
+if forecast_payload is not None: 
+    post_dataElements(dhis_url = DHIS_URL, payload = forecast_payload,
+                    token= DHIS_TOKEN, dryRun=dryRun)
+
+logger.info("Posting alerts to %s", DHIS_URL)
+
+try:
+    with open('output/alerts.json', 'r') as file:
+        alert_payload = json.load(file)
+except FileNotFoundError:
+        logger.warning("The file 'output/alerts.json' was not found and will not be posted. Run the calc_orgUnit_alerts step first")
+
+if alert_payload is not None: 
+    post_dataElements(dhis_url = DHIS_URL, payload = alert_payload,
+                    token= DHIS_TOKEN, dryRun=dryRun)
+
 

--- a/forecast/cli_r.sh
+++ b/forecast/cli_r.sh
@@ -44,8 +44,9 @@ case "$TASK" in
     exec Rscript /app/03_create-report.R "$@"
     ;;
   *)
-    echo "Error: Unknown forecast task '$TASK'"
-    echo "Usage: $0 {validate_inputs|forecast|report_only} [args...]"
+    echo "Error: Unknown forecast task: '$TASK'"
+    echo ""
+    print_usage
     exit 1
     ;;
 esac

--- a/labnotebook-docker_workflow.md
+++ b/labnotebook-docker_workflow.md
@@ -17,6 +17,14 @@ Building and pushing to Docker Hub (both images at once)
 docker compose -f compose-build.yaml build --no-cache && docker compose -f compose-build.yaml push
 ```
 
+## 2026-07-22
+
+Finalized local_CSB calculation and have updated the image to v0.1.2.
+
+## 2026-07-21
+
+Working on updating the CSB calculation to use local images
+
 ## 2026-06-25
 
 Updated the images to using explicit versioning, beginning with 0.1.0, to help with conflicts from local vs. built images. This is realted to issue #9.


### PR DESCRIPTION
This PR adds the capability to estimate alerts (CSB en Vigilance) locally. IT does so via the `calc_orgUnit_alerts` task in the `etl` image. 

Note that this adds an additional environmental variable called `ALERT_NAME`. Its default will result in an alert dataElement equal to `pridec_alert_disease` if the historic data was `pridec_historic_disease`. For the current PRIDE-C app, this are called `pridec_alert_CSBdiseaseVigilance` and should be provided manually as env variables. Although this is likely a structural change we should make to both the front end and backend together so that the codes are more standardized.

It also adds additional documentation to the cli dispatchers so that when the incorrect tasks is provided, the full usage statement prints.